### PR TITLE
fix(report): add global QUnit errors to reporter

### DIFF
--- a/listeners.js
+++ b/listeners.js
@@ -86,6 +86,10 @@
 		// Send acknowledgement to the server.
 		send( "ack" );
 
+		QUnit.on( "error", function( error ) {
+			send( "error", { message: error.message, stack: error.stack } );
+		} );
+
 		QUnit.on( "testEnd", function( data ) {
 			send( "testEnd", data );
 		} );

--- a/listeners.js
+++ b/listeners.js
@@ -87,7 +87,11 @@
 		send( "ack" );
 
 		QUnit.on( "error", function( error ) {
-			send( "error", { message: error.message, stack: error.stack } );
+			send( "error", {
+				message: error.message,
+				name: error.name,
+				stack: error.stack
+			} );
 		} );
 
 		QUnit.on( "testEnd", function( data ) {

--- a/reporter.js
+++ b/reporter.js
@@ -113,6 +113,12 @@ export function reportTest( test, { fullBrowser, id } ) {
 	}
 }
 
+export function reportError( error ) {
+	console.error( chalk.red( `\n\nError: ${ error.message }` ) );
+	console.error( chalk.gray( error.stack ) );
+	return error;
+}
+
 export function reportEnd( result, { descriptiveUrl, fullBrowser, id } ) {
 	console.log(
 		`\n\nTests finished in ${ prettyMs( result.runtime ) } ` +

--- a/reporter.js
+++ b/reporter.js
@@ -114,9 +114,14 @@ export function reportTest( test, { fullBrowser, id } ) {
 }
 
 export function reportError( error ) {
-	console.error( chalk.red( `\n\nError: ${ error.message }` ) );
-	console.error( chalk.gray( error.stack ) );
-	return error;
+	const title = `${ error.name || "Error" }: ${ error.message }`;
+	let message = chalk.red( title );
+
+	// Chromium error stacks include the title in the first line,
+	// but Firefox error stacks do not.
+	message += `\n${ chalk.gray( error.stack.replace( `${ title }\n`, "" ) ) }`;
+	console.error( `\n\n${ message }` );
+	return message;
 }
 
 export function reportEnd( result, { descriptiveUrl, fullBrowser, id } ) {

--- a/run.js
+++ b/run.js
@@ -85,10 +85,10 @@ export async function run( {
 					const reportId = message.id;
 					const report = reports[ reportId ];
 					touchBrowser( report.browser );
-					const errors = reportTest( message.data, report );
+					const errorMessage = reportTest( message.data, report );
 					pendingErrors[ reportId ] ??= Object.create( null );
-					if ( errors ) {
-						pendingErrors[ reportId ][ message.data.name ] = errors;
+					if ( errorMessage ) {
+						pendingErrors[ reportId ][ message.data.name ] = errorMessage;
 					} else {
 						const existing = pendingErrors[ reportId ][ message.data.name ];
 
@@ -112,7 +112,8 @@ export async function run( {
 					touchBrowser( report.browser );
 					reportError( message.data );
 					pendingErrors[ reportId ] ??= Object.create( null );
-					pendingErrors[ reportId ][ message.data.message ] = message.data.stack;
+					pendingErrors[ reportId ][ message.data.message ] =
+						`${ message.data.message }\n${ message.data.stack }`;
 					break;
 				}
 				case "runEnd": {
@@ -347,9 +348,9 @@ export async function run( {
 					stop = true;
 					console.error(
 						chalk.red(
-							`No tests were run with URL "${ report.url }" in ${ getBrowserString(
-								report.browser
-							) } (${ report.id })`
+							`No tests were run with URL "${ report.url }" in ${
+								report.fullBrowser
+							} (${ report.id })`
 						)
 					);
 				}

--- a/run.js
+++ b/run.js
@@ -110,10 +110,9 @@ export async function run( {
 					const reportId = message.id;
 					const report = reports[ reportId ];
 					touchBrowser( report.browser );
-					reportError( message.data );
+					const errorMessage = reportError( message.data );
 					pendingErrors[ reportId ] ??= Object.create( null );
-					pendingErrors[ reportId ][ message.data.message ] =
-						`${ message.data.message }\n${ message.data.stack }`;
+					pendingErrors[ reportId ][ message.data.message ] = errorMessage;
 					break;
 				}
 				case "runEnd": {


### PR DESCRIPTION
- Add errors from the QUnit `error` event to the list of error reports.
- If the `runEnd` failure count is greater than 0, but no errors are in the pending list, report a global failure instead and fail the test run.