### PR TITLE
ci(github): add lint workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
Add a GH workflow to run this repo's `npm test` command, which just runs lint right now. The real tests still happen in the submodules.